### PR TITLE
Updated docs to reflect the new Approov 2.6 usage for the `approov secret` command

### DIFF
--- a/workers/approov-token-binding/README.md
+++ b/workers/approov-token-binding/README.md
@@ -79,10 +79,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 #### Retrieve the Approov Secret
 
 ```text
-approov secret /path/to/approov/administration.token -get base64
+approov secret -get base64
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Base64 Secret in Cloudflare
 

--- a/workers/approov-token/README.md
+++ b/workers/approov-token/README.md
@@ -79,10 +79,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 #### Retrieve the Approov Secret
 
 ```text
-approov secret /path/to/approov/administration.token -get base64
+approov secret -get base64
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Base64 Secret in Cloudflare
 


### PR DESCRIPTION
Signed-off-by: Exadra37 <exadra37@gmail.com>